### PR TITLE
Fix project description

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # Write Code Every Day
 
-A project to honor those developers who believed in the challenge.
+A project to honor those developers who believe in the challenge.
 
 ## How to add yourself to this public list?
 


### PR DESCRIPTION
I changed the sentence "honor developers who __beleived__ in the challenge" to the past, as it is emphasizing developers who are still writing code every day rather than those who hold the longest streak.

Does it make sense to make the sentence "honor developers who __believe__ in the challenge"?